### PR TITLE
Potential fix for code scanning alert no. 253: Incorrect conversion between integer types

### DIFF
--- a/sql/yeartype.go
+++ b/sql/yeartype.go
@@ -15,16 +15,15 @@
 package sql
 
 import (
+	"math"
 	"reflect"
 	"strconv"
 	"time"
 
-	"github.com/shopspring/decimal"
-
 	"github.com/dolthub/vitess/go/sqltypes"
 	"github.com/dolthub/vitess/go/vt/proto/query"
+	"github.com/shopspring/decimal"
 	"gopkg.in/src-d/go-errors.v1"
-	"math"
 )
 
 var (

--- a/sql/yeartype.go
+++ b/sql/yeartype.go
@@ -24,6 +24,7 @@ import (
 	"github.com/dolthub/vitess/go/sqltypes"
 	"github.com/dolthub/vitess/go/vt/proto/query"
 	"gopkg.in/src-d/go-errors.v1"
+	"math"
 )
 
 var (
@@ -110,6 +111,9 @@ func (t yearType) Convert(v interface{}) (interface{}, error) {
 	case float32:
 		return t.Convert(int64(value))
 	case float64:
+		if value < float64(math.MinInt64) || value > float64(math.MaxInt64) {
+			return nil, ErrConvertingToYear.New("float64 value out of bounds for int64")
+		}
 		return t.Convert(int64(value))
 	case decimal.Decimal:
 		return t.Convert(value.IntPart())


### PR DESCRIPTION
Potential fix for [https://github.com/trimble-oss/go-mysql-server/security/code-scanning/253](https://github.com/trimble-oss/go-mysql-server/security/code-scanning/253)

The best way to fix the issue is to add bounds checks to ensure the `float64` value fits within the range of `int64` before converting. This can be achieved using constants from the `math` package (`math.MinInt64` and `math.MaxInt64`). Additionally, the code should return an error or a default value if the bounds are violated.

To implement the fix, we need to modify the `t.Convert()` method in the `yearType` struct to include bounds checks for `float64` values before converting them to `int64`. The changes will be applied to the relevant section of the `switch` statement handling the `float64` case.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
