### PR TITLE
Potential fix for code scanning alert no. 221: Incorrect conversion between integer types

### DIFF
--- a/sql/system_settype.go
+++ b/sql/system_settype.go
@@ -90,6 +90,9 @@ func (t systemSetType) Convert(v interface{}) (interface{}, error) {
 		// Float values aren't truly accepted, but the engine will give them when it should give ints.
 		// Therefore, if the float doesn't have a fractional portion, we treat it as an int.
 		if value == float64(int64(value)) {
+			if value < float64(math.MinInt64) || value > float64(math.MaxInt64) {
+				return nil, ErrInvalidSystemVariableValue.New(t.varName, v)
+			}
 			return t.SetType.Convert(int64(value))
 		}
 	case decimal.Decimal:


### PR DESCRIPTION
Potential fix for [https://github.com/trimble-oss/go-mysql-server/security/code-scanning/221](https://github.com/trimble-oss/go-mysql-server/security/code-scanning/221)

To resolve the issue, the conversion of `float64` to `int64` must include an explicit check to ensure the value lies within the valid range for `int64`. The `math` package defines constants `math.MaxInt64` and `math.MinInt64`, which can be used for this purpose. If the value is out of bounds, an appropriate error should be returned to prevent invalid conversions from propagating through the system.

Specifically:
1. Before converting `value` to `int64`, check if it is within the range `[math.MinInt64, math.MaxInt64]`.
2. If `value` is out of bounds, return an error indicating the invalid conversion.
3. Ensure that this fix does not disrupt the existing logic for handling fractional `float64` values.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
