### PR TITLE
Potential fix for code scanning alert no. 197: Incorrect conversion between integer types

### DIFF
--- a/sql/system_booltype.go
+++ b/sql/system_booltype.go
@@ -98,7 +98,10 @@ func (t systemBoolType) Convert(v interface{}) (interface{}, error) {
 		// Float values aren't truly accepted, but the engine will give them when it should give ints.
 		// Therefore, if the float doesn't have a fractional portion, we treat it as an int.
 		if value == float64(int64(value)) {
-			return t.Convert(int64(value))
+			if value >= float64(math.MinInt64) && value <= float64(math.MaxInt64) {
+				return t.Convert(int64(value))
+			}
+			return nil, ErrInvalidSystemVariableValue.New(t.varName, v)
 		}
 	case decimal.Decimal:
 		f, _ := value.Float64()

--- a/sql/system_booltype.go
+++ b/sql/system_booltype.go
@@ -15,6 +15,7 @@
 package sql
 
 import (
+	"math"
 	"reflect"
 	"strconv"
 	"strings"


### PR DESCRIPTION
Potential fix for [https://github.com/trimble-oss/go-mysql-server/security/code-scanning/197](https://github.com/trimble-oss/go-mysql-server/security/code-scanning/197)

To address the issue, we need to ensure that the conversion from `float64` to `int64` is safe and does not result in undefined behavior. This can be achieved by adding explicit bounds checks before performing the conversion. Specifically:
1. Check that the `float64` value is within the range of `int64` (i.e., between `math.MinInt64` and `math.MaxInt64`).
2. If the value is out of bounds, return an appropriate error or handle the case gracefully.

The changes will be made in the `Convert` method of the `systemBoolType` struct in `sql/system_booltype.go`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
