### PR TITLE
Potential fix for code scanning alert no. 268: Incorrect conversion between integer types

### DIFF
--- a/sql/system_settype.go
+++ b/sql/system_settype.go
@@ -90,12 +90,13 @@ func (t systemSetType) Convert(v interface{}) (interface{}, error) {
 	case float64:
 		// Float values aren't truly accepted, but the engine will give them when it should give ints.
 		// Therefore, if the float doesn't have a fractional portion, we treat it as an int.
-		if value == float64(int64(value)) {
-			if value < float64(math.MinInt64) || value > float64(math.MaxInt64) {
-				return nil, ErrInvalidSystemVariableValue.New(t.varName, v)
+		if value >= float64(math.MinInt64) && value <= float64(math.MaxInt64) {
+			intValue := int64(value)
+			if float64(intValue) == value {
+				return t.SetType.Convert(intValue)
 			}
-			return t.SetType.Convert(int64(value))
 		}
+		return nil, ErrInvalidSystemVariableValue.New(t.varName, v)
 	case decimal.Decimal:
 		f, _ := value.Float64()
 		return t.Convert(f)


### PR DESCRIPTION
Potential fix for [https://github.com/trimble-oss/go-mysql-server/security/code-scanning/268](https://github.com/trimble-oss/go-mysql-server/security/code-scanning/268)

To address the issue, the conversion from `float64` to `int64` should be modified to ensure that the bounds check is performed before the conversion. Additionally, the logic should be updated to avoid relying on implicit assumptions about the safety of the conversion. This can be achieved by explicitly checking the bounds and returning an error if the value is out of range.

The fix involves:
1. Adding a bounds check before performing the conversion from `float64` to `int64`.
2. Ensuring that the conversion logic is robust and does not rely on implicit assumptions.
3. Updating the `Convert` method in `systemSetType` to handle edge cases explicitly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
