### PR TITLE
Potential fix for code scanning alert no. 270: Incorrect conversion between integer types

### DIFF
--- a/sql/system_booltype.go
+++ b/sql/system_booltype.go
@@ -92,7 +92,10 @@ func (t systemBoolType) Convert(v interface{}) (interface{}, error) {
 			return int8(value), nil
 		}
 	case uint64:
-		return t.Convert(int64(value))
+		if value <= math.MaxInt64 {
+			return t.Convert(int64(value))
+		}
+		return nil, ErrInvalidSystemVariableValue.New(t.varName, v)
 	case float32:
 		return t.Convert(float64(value))
 	case float64:
@@ -100,7 +103,10 @@ func (t systemBoolType) Convert(v interface{}) (interface{}, error) {
 		// Therefore, if the float doesn't have a fractional portion, we treat it as an int.
 		if value == float64(int64(value)) {
 			if value >= float64(math.MinInt64) && value <= float64(math.MaxInt64) {
-				return t.Convert(int64(value))
+				if intVal := int64(value); intVal >= math.MinInt8 && intVal <= math.MaxInt8 {
+					return t.Convert(intVal)
+				}
+				return nil, ErrInvalidSystemVariableValue.New(t.varName, v)
 			}
 			return nil, ErrInvalidSystemVariableValue.New(t.varName, v)
 		}


### PR DESCRIPTION
Potential fix for [https://github.com/trimble-oss/go-mysql-server/security/code-scanning/270](https://github.com/trimble-oss/go-mysql-server/security/code-scanning/270)

To resolve the issue, the conversion process should ensure that values are within the bounds of the target type to prevent overflow or incorrect results. This can be achieved by explicitly checking the bounds before performing the conversion. For unsigned integers (`uint64`), an upper bound check against `math.MaxInt64` should be added prior to converting to `int64`.

The fix involves:
1. Adding a conditional check for `uint64` values to ensure they do not exceed `math.MaxInt64` before converting them to `int64`.
2. Ensuring other cases that involve conversion to smaller integer types also perform appropriate bounds checks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
