### PR TITLE
Potential fix for code scanning alert no. 368: Potentially unsafe quoting

### DIFF
--- a/sql/rowexec/show_iters.go
+++ b/sql/rowexec/show_iters.go
@@ -398,7 +398,10 @@ func convertColumnDefaultToString(ctx *sql.Context, def *sql.ColumnDefaultValue)
 	if types.IsBit(def.OutType) {
 		return fmt.Sprintf("b'%b'", v), nil
 	}
-	return fmt.Sprintf("'%v'", v), nil
+	// Escape single quotes and backslashes in v to prevent SQL injection
+	sanitizedValue := strings.ReplaceAll(fmt.Sprintf("%v", v), `\`, `\\`)
+	sanitizedValue = strings.ReplaceAll(sanitizedValue, `'`, `\'`)
+	return fmt.Sprintf("'%s'", sanitizedValue), nil
 }
 
 func (i *showCreateTablesIter) produceCreateTableStatement(ctx *sql.Context, table sql.Table, schema sql.Schema, pkSchema sql.PrimaryKeySchema) (string, error) {


### PR DESCRIPTION
Potential fix for [https://github.com/trimble-oss/go-mysql-server/security/code-scanning/368](https://github.com/trimble-oss/go-mysql-server/security/code-scanning/368)

To fix this issue, we need to ensure that single quotes and other potentially dangerous characters in `v` are escaped correctly before being embedded into the SQL query string. This can be achieved by using a dedicated sanitization mechanism such as `strings.ReplaceAll` or adopting a structured API that avoids manual string construction.

**Best way to fix:**
1. Escape single quotes within the value of `v` using `strings.ReplaceAll` to ensure that embedded quotes do not break the SQL structure.
2. Replace the `fmt.Sprintf("'%v'", v)` with a sanitized version of `v` where single quotes and backslashes are appropriately escaped.
3. Implement this directly within the `convertColumnDefaultToString` function.

**Required changes:**
- Add sanitization logic using `strings.ReplaceAll` in the `convertColumnDefaultToString` function in `sql/rowexec/show_iters.go`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
