### PR TITLE
Potential fix for code scanning alert no. 253: Incorrect conversion between integer types

### DIFF
--- a/sql/yeartype.go
+++ b/sql/yeartype.go
@@ -106,6 +106,9 @@ func (t yearType) Convert(v interface{}) (interface{}, error) {
 			return int16(value), nil
 		}
 	case uint64:
+		if value > math.MaxInt64 {
+			return nil, ErrConvertingToYear.New("uint64 value out of bounds for int64")
+		}
 		return t.Convert(int64(value))
 	case float32:
 		return t.Convert(int64(value))


### PR DESCRIPTION
Potential fix for [https://github.com/trimble-oss/go-mysql-server/security/code-scanning/253](https://github.com/trimble-oss/go-mysql-server/security/code-scanning/253)

To address the issue, ensure that the `uint64` value is within the valid range for `int64` before performing the conversion. Specifically:
1. Add a bounds check to verify that the `uint64` value does not exceed `math.MaxInt64`. 
2. If the value exceeds the maximum allowed for `int64`, return an appropriate error indicating the value is out of bounds.
3. Update the `case uint64` block in the `Convert` method to include this logic.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
