### PR TITLE
Potential fix for code scanning alert no. 395: Clear-text logging of sensitive information

### DIFF
--- a/sql/analyzer/analyzer.go
+++ b/sql/analyzer/analyzer.go
@@ -312,9 +312,13 @@ func sanitizeArguments(args []interface{}) []interface{} {
 			args[i] = sanitizeMap(v)
 		case []interface{}:
 			args[i] = sanitizeArguments(v)
+		case plan.AuthenticationMysqlNativePassword:
+			args[i] = "[PASSWORD_REDACTED]"
 		default:
 			if reflect.TypeOf(arg).Kind() == reflect.Struct {
 				args[i] = "[STRUCT_REDACTED]"
+			} else {
+				args[i] = "[REDACTED]"
 			}
 		}
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/trimble-oss/go-mysql-server/security/code-scanning/395](https://github.com/trimble-oss/go-mysql-server/security/code-scanning/395)

To fix the issue, we need to ensure that sensitive information, such as passwords, is never logged in clear text. The best approach is to enhance the sanitization logic to explicitly handle known sensitive data types, such as `plan.AuthenticationMysqlNativePassword`, and redact them. Additionally, we should add a safeguard to prevent logging of any unrecognized sensitive data structures.

1. Update the `sanitizeArguments` function to explicitly handle sensitive data types like `plan.AuthenticationMysqlNativePassword` and redact their contents.
2. Ensure that any unrecognized data structures are replaced with a generic "[REDACTED]" placeholder.
3. Modify the `Log` function to use the enhanced sanitization logic before logging messages.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
