### PR TITLE
Potential fix for code scanning alert no. 231: Incorrect conversion between integer types

### DIFF
--- a/sql/timetype.go
+++ b/sql/timetype.go
@@ -175,6 +175,9 @@ func (t timespanType) ConvertToTimespan(v interface{}) (Timespan, error) {
 	case float32:
 		return t.ConvertToTimespan(float64(value))
 	case float64:
+		if value < float64(math.MinInt64) || value > float64(math.MaxInt64) {
+			return Timespan(0), fmt.Errorf("float64 value %f exceeds int64 bounds", value)
+		}
 		intValue := int64(value)
 		microseconds := int64Abs(int64(math.Round((value - float64(intValue)) * float64(microsecondsPerSecond))))
 		absValue := int64Abs(intValue)


### PR DESCRIPTION
Potential fix for [https://github.com/trimble-oss/go-mysql-server/security/code-scanning/231](https://github.com/trimble-oss/go-mysql-server/security/code-scanning/231)

To fix the problem, we need to ensure that before converting a `float64` value to `int64` in the `ConvertToTimespan` method, we check that the value is within the valid range for `int64`. Specifically, we should check that the value is greater than or equal to `math.MinInt64` and less than or equal to `math.MaxInt64`. If the value is outside this range, we should return an error indicating that the value is out of bounds. This change should be made in the `case float64:` block of the `ConvertToTimespan` function in `sql/timetype.go`, before the conversion on line 178.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
