### PR TITLE
Potential fix for code scanning alert no. 266: Checkout of untrusted code in trusted context

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -58,8 +58,6 @@ jobs:
           go-version: ^1.19
         id: go
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.head_ref }}
       - name: Check all
         id: check_format
         run: |


### PR DESCRIPTION
Potential fix for [https://github.com/trimble-oss/go-mysql-server/security/code-scanning/266](https://github.com/trimble-oss/go-mysql-server/security/code-scanning/266)

In general, to fix this type of issue you should avoid explicitly checking out the pull request head commit in a privileged or semi‑privileged workflow, and instead rely on the default behavior of `actions/checkout` for `pull_request` events (which checks out the merge commit) or restructure into separate unprivileged and privileged workflows as described in the background. This prevents unreviewed PR code from being executed with elevated repository access.

For this specific workflow, the minimal, behavior‑preserving fix is to stop forcing `actions/checkout` to use `ref: ${{ github.head_ref }}` in the `verify` job. When `on: pull_request` is used, omitting the `ref` causes `actions/checkout@v3` to check out the merge commit of the PR into the base branch in a safe, read‑only context. The `verify` job only needs to see the combined changes to run `./check_repo.sh`; it does not need to execute the PR’s own version of that script from the head ref. Therefore:

- In `.github/workflows/format.yml`, within the `verify` job, remove the `with:` block that sets `ref: ${{ github.head_ref }}` on the `actions/checkout@v3` step (lines 61–62).
- Leave the rest of the workflow unchanged; `format` and `alt-verify` behavior remain the same.
- No new imports or actions are needed.

This change ensures that the `verify` job runs against the safe merge ref and no longer explicitly pulls and executes potentially untrusted PR‑head scripts in a way that triggers the CodeQL warning.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
